### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/host/augeas.rb
+++ b/lib/puppet/provider/host/augeas.rb
@@ -3,6 +3,7 @@
 # Copyright (c) 2012 Dominic Cleal
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:host).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update hosts file"
 

--- a/lib/puppet/provider/mailalias/augeas.rb
+++ b/lib/puppet/provider/mailalias/augeas.rb
@@ -3,6 +3,7 @@
 # Copyright (c) 2012 Dominic Cleal
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:mailalias).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update mail aliases file"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.